### PR TITLE
Allow loading shader resources from arbitrary mods

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/shader/ShaderLoader.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/shader/ShaderLoader.java
@@ -25,7 +25,7 @@ public class ShaderLoader {
     public static String getShaderSource(Identifier name) {
         String path = String.format("/assets/%s/shaders/%s", name.getNamespace(), name.getPath());
 
-        try (InputStream in = ShaderLoader.class.getResourceAsStream(path)) {
+        try (InputStream in = ShaderLoader.class.getClassLoader().getResourceAsStream(path)) {
             if (in == null) {
                 throw new RuntimeException("Shader not found: " + path);
             }


### PR DESCRIPTION
Restores expected behavior for `ShaderLoader#getShaderSource` to allow loading shader files from any mod present on the classpath. Embeddium uses the class object for locating resources, which behaves differently in a modular environment. Using this method, SJH's classloader will only search for resources in the caller's module, making it impossible to load shaders from other mods, including nvidium.

The fix is quite simple - moving getResourceAsStream to be called on the original class's classloader instead, which searches all loaded mods for the specified resource.

Might require porting to newer versions of embeddium, too.

Fixes Sinytra/Connector#518