### PR TITLE
Enablement work for future core shader support

### DIFF
--- a/src/api/java/net/caffeinemc/mods/sodium/api/util/ColorMixer.java
+++ b/src/api/java/net/caffeinemc/mods/sodium/api/util/ColorMixer.java
@@ -59,4 +59,27 @@ public class ColorMixer {
         // Pack the components
         return (c0 <<  0) | (c1 <<  8) | (c2 << 16) | (c3 << 24);
     }
+
+    /**
+     * Multiplies all channels of a 32-bit color with an 8-bit value.
+     * <p>
+     * The order of the channels within the packed color does not matter, and the output color will always
+     * have the same ordering as the input color.
+     *
+     * @param a The first color to multiply
+     * @param val The 8-bit value to multiply by
+     * @return The multiplied color in packed 32-bit format
+     */
+    public static int mulSingle(int a, int val) {
+        val &= 0xFF;
+        // Take each 8-bit component pair, multiply them together to create intermediate 16-bit integers,
+        // and then shift the high half of each 16-bit integer into 8-bit integers.
+        int c0 = (((a >>  0) & 0xFF) * val) >> 8;
+        int c1 = (((a >>  8) & 0xFF) * val) >> 8;
+        int c2 = (((a >> 16) & 0xFF) * val) >> 8;
+        int c3 = (((a >> 24) & 0xFF) * val) >> 8;
+
+        // Pack the components
+        return (c0 <<  0) | (c1 <<  8) | (c2 << 16) | (c3 << 24);
+    }
 }

--- a/src/api/java/net/caffeinemc/mods/sodium/api/util/NormI8.java
+++ b/src/api/java/net/caffeinemc/mods/sodium/api/util/NormI8.java
@@ -1,5 +1,8 @@
 package net.caffeinemc.mods.sodium.api.util;
 
+import net.minecraft.Util;
+import net.minecraft.core.Direction;
+import net.minecraft.core.Vec3i;
 import net.minecraft.util.Mth;
 import org.joml.Vector3f;
 
@@ -26,6 +29,14 @@ public class NormI8 {
      * multiplication is slightly faster than a floating point division, and this code is a hot path which justifies it.
      */
     private static final float NORM = 1.0f / COMPONENT_RANGE;
+
+    public static final int[] FOR_DIRECTIONS = Util.make(new int[Direction.values().length], arr -> {
+        Direction[] directions = Direction.values();
+        for(int i = 0; i < directions.length; i++) {
+            Vec3i normal = directions[i].getNormal();
+            arr[i] = NormI8.pack(normal.getX(), normal.getY(), normal.getZ());
+        }
+    });
 
     public static int pack(Vector3f normal) {
         return pack(normal.x(), normal.y(), normal.z());

--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/attribute/GlVertexAttributeFormat.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/attribute/GlVertexAttributeFormat.java
@@ -8,6 +8,7 @@ import org.lwjgl.opengl.GL20C;
 public record GlVertexAttributeFormat(int typeId, int size) {
     public static final GlVertexAttributeFormat FLOAT = new GlVertexAttributeFormat(GL20C.GL_FLOAT, 4);
     public static final GlVertexAttributeFormat UNSIGNED_SHORT = new GlVertexAttributeFormat(GL20C.GL_UNSIGNED_SHORT, 2);
+    public static final GlVertexAttributeFormat SIGNED_BYTE = new GlVertexAttributeFormat(GL20C.GL_BYTE, 1);
     public static final GlVertexAttributeFormat UNSIGNED_BYTE = new GlVertexAttributeFormat(GL20C.GL_UNSIGNED_BYTE, 1);
     public static final GlVertexAttributeFormat UNSIGNED_INT = new GlVertexAttributeFormat(GL20C.GL_UNSIGNED_INT, 4);
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/attribute/GlVertexFormat.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/attribute/GlVertexFormat.java
@@ -98,11 +98,9 @@ public class GlVertexFormat<T extends Enum<T>> {
             for (T key : this.type.getEnumConstants()) {
                 GlVertexAttribute attribute = this.attributes.get(key);
 
-                if (attribute == null) {
-                    throw new NullPointerException("Generic attribute not assigned to enumeration " + key.name());
+                if (attribute != null) {
+                    size = Math.max(size, attribute.getPointer() + attribute.getSize());
                 }
-
-                size = Math.max(size, attribute.getPointer() + attribute.getSize());
             }
 
             // The stride must be large enough to cover all attributes. This still allows for additional padding

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -45,6 +45,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.fml.loading.FMLLoader;
+import org.embeddedt.embeddium.render.chunk.ChunkVertexTypeManager;
 
 import java.util.*;
 import java.util.function.Consumer;
@@ -270,6 +271,8 @@ public class SodiumWorldRenderer {
             this.renderSectionManager.destroy();
             this.renderSectionManager = null;
         }
+
+        ChunkVertexTypeManager.updateType();
 
         this.renderDistance = this.client.options.getEffectiveRenderDistance();
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
@@ -29,9 +29,9 @@ import org.lwjgl.system.MemoryUtil;
 import java.util.Iterator;
 
 public class DefaultChunkRenderer extends ShaderChunkRenderer {
-    private final MultiDrawBatch batch;
+    protected final MultiDrawBatch batch;
 
-    private final SharedQuadIndexBuffer sharedIndexBuffer;
+    protected final SharedQuadIndexBuffer sharedIndexBuffer;
 
     private final GlVertexAttributeBinding[] vertexAttributeBindings;
 
@@ -132,7 +132,7 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
     }
 
     @SuppressWarnings("IntegerMultiplicationImplicitCastToLong")
-    private static void addDrawCommands(MultiDrawBatch batch, long pMeshData, int mask) {
+    protected static void addDrawCommands(MultiDrawBatch batch, long pMeshData, int mask) {
         final var pBaseVertex = batch.pBaseVertex;
         final var pElementCount = batch.pElementCount;
 
@@ -157,7 +157,7 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
     private static final int MODEL_NEG_Y      = ModelQuadFacing.NEG_Y.ordinal();
     private static final int MODEL_NEG_Z      = ModelQuadFacing.NEG_Z.ordinal();
 
-    private static int getVisibleFaces(int originX, int originY, int originZ, int chunkX, int chunkY, int chunkZ) {
+    protected static int getVisibleFaces(int originX, int originY, int originZ, int chunkX, int chunkY, int chunkZ) {
         // This is carefully written so that we can keep everything branch-less.
         //
         // Normally, this would be a ridiculous way to handle the problem. But the Hotspot VM's
@@ -211,7 +211,7 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
         return (chunkBlockPos - cameraBlockPos) - cameraPos;
     }
 
-    private GlTessellation prepareTessellation(CommandList commandList, RenderRegion region) {
+    protected final GlTessellation prepareTessellation(CommandList commandList, RenderRegion region) {
         var resources = region.getResources();
         var tessellation = resources.getTessellation();
 
@@ -257,7 +257,7 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
         });
     }
 
-    private static void executeDrawBatch(CommandList commandList, GlTessellation tessellation, MultiDrawBatch batch) {
+    protected static void executeDrawBatch(CommandList commandList, GlTessellation tessellation, MultiDrawBatch batch) {
         try (DrawCommandList drawCommandList = commandList.beginTessellating(tessellation)) {
             drawCommandList.multiDrawElementsBaseVertex(batch, GlIndexType.UNSIGNED_INT);
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/DefaultChunkRenderer.java
@@ -41,7 +41,7 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
         this.batch = new MultiDrawBatch((ModelQuadFacing.COUNT * RenderRegion.REGION_SIZE) + 1);
         this.sharedIndexBuffer = new SharedQuadIndexBuffer(device.createCommandList(), SharedQuadIndexBuffer.IndexType.INTEGER);
 
-        this.vertexAttributeBindings = getBindingsForType();
+        this.vertexAttributeBindings = vertexType.getAttributeBindings();
     }
 
     @Override
@@ -220,34 +220,6 @@ public class DefaultChunkRenderer extends ShaderChunkRenderer {
         }
 
         return tessellation;
-    }
-
-    private GlVertexAttributeBinding[] getBindingsForType() {
-        if(this.vertexType == ChunkMeshFormats.COMPACT) {
-            return new GlVertexAttributeBinding[] {
-                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_POSITION_ID,
-                            this.vertexFormat.getAttribute(ChunkMeshAttribute.POSITION_MATERIAL_MESH)),
-                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_COLOR,
-                            this.vertexFormat.getAttribute(ChunkMeshAttribute.COLOR_SHADE)),
-                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_BLOCK_TEXTURE,
-                            this.vertexFormat.getAttribute(ChunkMeshAttribute.BLOCK_TEXTURE)),
-                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_LIGHT_TEXTURE,
-                            this.vertexFormat.getAttribute(ChunkMeshAttribute.LIGHT_TEXTURE))
-            };
-        } else if(this.vertexType == ChunkMeshFormats.VANILLA_LIKE) {
-            GlVertexFormat<ChunkMeshAttribute> vanillaFormat = this.vertexFormat;
-            return new GlVertexAttributeBinding[] {
-                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_POSITION_ID,
-                            vanillaFormat.getAttribute(ChunkMeshAttribute.POSITION_MATERIAL_MESH)),
-                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_COLOR,
-                            vanillaFormat.getAttribute(ChunkMeshAttribute.COLOR_SHADE)),
-                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_BLOCK_TEXTURE,
-                            vanillaFormat.getAttribute(ChunkMeshAttribute.BLOCK_TEXTURE)),
-                    new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_LIGHT_TEXTURE,
-                            vanillaFormat.getAttribute(ChunkMeshAttribute.LIGHT_TEXTURE)),
-            };
-        } else
-            return null; // assume Oculus/Iris will take over
     }
 
     private GlTessellation createRegionTessellation(CommandList commandList, RenderRegion.DeviceResources resources) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -64,6 +64,8 @@ import java.util.*;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class RenderSectionManager {
+    private static final boolean USE_CORE_SHADERS = Boolean.getBoolean("embeddium.useVanillaCoreShaders");
+
     private final ChunkBuilder builder;
 
     private final Thread renderThread = Thread.currentThread();
@@ -104,9 +106,17 @@ public class RenderSectionManager {
     private final int translucencyBlockRenderDistance;
 
     public RenderSectionManager(ClientLevel world, int renderDistance, CommandList commandList) {
-        ChunkVertexType vertexType = SodiumClientMod.canUseVanillaVertices() ? ChunkMeshFormats.VANILLA_LIKE : ChunkMeshFormats.COMPACT;
+        ChunkVertexType vertexType;
 
-        this.chunkRenderer = new DefaultChunkRenderer(RenderDevice.INSTANCE, vertexType);
+        if (USE_CORE_SHADERS) {
+            vertexType = ChunkMeshFormats.VANILLA;
+        } else if (SodiumClientMod.canUseVanillaVertices()) {
+            vertexType = ChunkMeshFormats.VANILLA_LIKE;
+        } else {
+            vertexType = ChunkMeshFormats.COMPACT;
+        }
+
+        this.chunkRenderer = USE_CORE_SHADERS ? new VanillaShaderChunkRenderer(RenderDevice.INSTANCE, vertexType) : new DefaultChunkRenderer(RenderDevice.INSTANCE, vertexType);
 
         this.vertexType = vertexType;
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -106,7 +106,7 @@ public class RenderSectionManager {
     public RenderSectionManager(ClientLevel world, int renderDistance, CommandList commandList) {
         ChunkVertexType vertexType = SodiumClientMod.canUseVanillaVertices() ? ChunkMeshFormats.VANILLA_LIKE : ChunkMeshFormats.COMPACT;
 
-        this.chunkRenderer = new VanillaShaderChunkRenderer(RenderDevice.INSTANCE, vertexType);
+        this.chunkRenderer = new DefaultChunkRenderer(RenderDevice.INSTANCE, vertexType);
 
         this.vertexType = vertexType;
 
@@ -116,7 +116,7 @@ public class RenderSectionManager {
         this.needsUpdate = true;
         this.renderDistance = renderDistance;
 
-        this.regions = new RenderRegionManager(commandList);
+        this.regions = new RenderRegionManager(commandList, vertexType);
         this.sectionCache = new ClonedChunkSectionCache(this.world);
 
         this.renderLists = SortedRenderLists.empty();

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -55,6 +55,7 @@ import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.phys.Vec3;
 import org.apache.commons.lang3.ArrayUtils;
 import org.embeddedt.embeddium.chunk.VanillaShaderChunkRenderer;
+import org.embeddedt.embeddium.render.chunk.ChunkVertexTypeManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -64,7 +65,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class RenderSectionManager {
-    private static final boolean USE_CORE_SHADERS = Boolean.getBoolean("embeddium.useVanillaCoreShaders");
+    public static final boolean USE_CORE_SHADERS = Boolean.getBoolean("embeddium.useVanillaCoreShaders");
 
     private final ChunkBuilder builder;
 
@@ -106,15 +107,7 @@ public class RenderSectionManager {
     private final int translucencyBlockRenderDistance;
 
     public RenderSectionManager(ClientLevel world, int renderDistance, CommandList commandList) {
-        ChunkVertexType vertexType;
-
-        if (USE_CORE_SHADERS) {
-            vertexType = ChunkMeshFormats.VANILLA;
-        } else if (SodiumClientMod.canUseVanillaVertices()) {
-            vertexType = ChunkMeshFormats.VANILLA_LIKE;
-        } else {
-            vertexType = ChunkMeshFormats.COMPACT;
-        }
+        ChunkVertexType vertexType = ChunkVertexTypeManager.getType();
 
         this.chunkRenderer = USE_CORE_SHADERS ? new VanillaShaderChunkRenderer(RenderDevice.INSTANCE) : new DefaultChunkRenderer(RenderDevice.INSTANCE, vertexType);
 
@@ -126,7 +119,7 @@ public class RenderSectionManager {
         this.needsUpdate = true;
         this.renderDistance = renderDistance;
 
-        this.regions = new RenderRegionManager(commandList, vertexType);
+        this.regions = new RenderRegionManager(commandList);
         this.sectionCache = new ClonedChunkSectionCache(this.world);
 
         this.renderLists = SortedRenderLists.empty();

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -116,7 +116,7 @@ public class RenderSectionManager {
             vertexType = ChunkMeshFormats.COMPACT;
         }
 
-        this.chunkRenderer = USE_CORE_SHADERS ? new VanillaShaderChunkRenderer(RenderDevice.INSTANCE, vertexType) : new DefaultChunkRenderer(RenderDevice.INSTANCE, vertexType);
+        this.chunkRenderer = USE_CORE_SHADERS ? new VanillaShaderChunkRenderer(RenderDevice.INSTANCE) : new DefaultChunkRenderer(RenderDevice.INSTANCE, vertexType);
 
         this.vertexType = vertexType;
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -54,6 +54,7 @@ import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.phys.Vec3;
 import org.apache.commons.lang3.ArrayUtils;
+import org.embeddedt.embeddium.chunk.VanillaShaderChunkRenderer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -105,7 +106,7 @@ public class RenderSectionManager {
     public RenderSectionManager(ClientLevel world, int renderDistance, CommandList commandList) {
         ChunkVertexType vertexType = SodiumClientMod.canUseVanillaVertices() ? ChunkMeshFormats.VANILLA_LIKE : ChunkMeshFormats.COMPACT;
 
-        this.chunkRenderer = new DefaultChunkRenderer(RenderDevice.INSTANCE, vertexType);
+        this.chunkRenderer = new VanillaShaderChunkRenderer(RenderDevice.INSTANCE, vertexType);
 
         this.vertexType = vertexType;
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/BlockRenderer.java
@@ -24,6 +24,7 @@ import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEn
 import me.jellysquid.mods.sodium.client.util.DirectionUtil;
 import me.jellysquid.mods.sodium.client.util.ModelQuadUtil;
 import net.caffeinemc.mods.sodium.api.util.ColorABGR;
+import net.caffeinemc.mods.sodium.api.util.NormI8;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.BakedQuad;
@@ -231,6 +232,8 @@ public class BlockRenderer {
             out.v = quad.getTexV(srcIndex);
 
             out.light = ModelQuadUtil.mergeBakedLight(quad.getLight(srcIndex), light.lm[srcIndex]);
+
+            out.normal = NormI8.FOR_DIRECTIONS[quad.getLightFace().ordinal()];
         }
 
         var vertexBuffer = builder.getVertexBuffer(normalFace);

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/region/RenderRegion.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/region/RenderRegion.java
@@ -19,6 +19,7 @@ import me.jellysquid.mods.sodium.client.util.MathUtil;
 import net.minecraft.core.SectionPos;
 import org.apache.commons.lang3.Validate;
 import org.embeddedt.embeddium.render.ShaderModBridge;
+import org.embeddedt.embeddium.render.chunk.ChunkVertexTypeManager;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -185,14 +186,9 @@ public class RenderRegion {
         return this.resources;
     }
 
-    @Deprecated
     public DeviceResources createResources(CommandList commandList) {
-        return createResources(commandList, ChunkMeshFormats.COMPACT);
-    }
-
-    public DeviceResources createResources(CommandList commandList, ChunkVertexType type) {
         if (this.resources == null) {
-            this.resources = new DeviceResources(commandList, this.stagingBuffer, type);
+            this.resources = new DeviceResources(commandList, this.stagingBuffer);
         }
 
         return this.resources;
@@ -213,14 +209,14 @@ public class RenderRegion {
         private final GlBufferArena geometryArena;
         private GlTessellation tessellation;
 
-        public DeviceResources(CommandList commandList, StagingBuffer stagingBuffer, ChunkVertexType type) {
+        public DeviceResources(CommandList commandList, StagingBuffer stagingBuffer) {
             int stride;
             // TODO - remove this when Iris isn't supported anymore
             if(ShaderModBridge.areShadersEnabled()) {
                 // Iris redirects the COMPACT field access here to its own vertex type
                 stride = ChunkMeshFormats.COMPACT.getVertexFormat().getStride();
             } else {
-                stride = type.getVertexFormat().getStride();
+                stride = ChunkVertexTypeManager.getType().getVertexFormat().getStride();
             }
             this.geometryArena = new GlBufferArena(commandList, REGION_SIZE * 756, stride, stagingBuffer);
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/region/RenderRegionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/region/RenderRegionManager.java
@@ -19,8 +19,6 @@ import me.jellysquid.mods.sodium.client.render.chunk.data.SectionRenderDataStora
 import me.jellysquid.mods.sodium.client.render.chunk.region.RenderRegion.DeviceResources;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.DefaultTerrainRenderPasses;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
-import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshFormats;
-import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -29,16 +27,9 @@ public class RenderRegionManager {
     private final Long2ReferenceOpenHashMap<RenderRegion> regions = new Long2ReferenceOpenHashMap<>();
 
     private final StagingBuffer stagingBuffer;
-    private final ChunkVertexType vertexType;
 
-    @Deprecated
     public RenderRegionManager(CommandList commandList) {
-        this(commandList, ChunkMeshFormats.COMPACT);
-    }
-
-    public RenderRegionManager(CommandList commandList, ChunkVertexType type) {
         this.stagingBuffer = createStagingBuffer(commandList);
-        this.vertexType = type;
     }
 
     public void update() {
@@ -95,7 +86,7 @@ public class RenderRegionManager {
             return;
         }
 
-        var resources = region.createResources(commandList, vertexType);
+        var resources = region.createResources(commandList);
         var arena = resources.getGeometryArena();
 
         boolean bufferChanged = arena.upload(commandList, uploads.stream()

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/region/RenderRegionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/region/RenderRegionManager.java
@@ -19,6 +19,8 @@ import me.jellysquid.mods.sodium.client.render.chunk.data.SectionRenderDataStora
 import me.jellysquid.mods.sodium.client.render.chunk.region.RenderRegion.DeviceResources;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.DefaultTerrainRenderPasses;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshFormats;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -27,9 +29,16 @@ public class RenderRegionManager {
     private final Long2ReferenceOpenHashMap<RenderRegion> regions = new Long2ReferenceOpenHashMap<>();
 
     private final StagingBuffer stagingBuffer;
+    private final ChunkVertexType vertexType;
 
+    @Deprecated
     public RenderRegionManager(CommandList commandList) {
+        this(commandList, ChunkMeshFormats.COMPACT);
+    }
+
+    public RenderRegionManager(CommandList commandList, ChunkVertexType type) {
         this.stagingBuffer = createStagingBuffer(commandList);
+        this.vertexType = type;
     }
 
     public void update() {
@@ -86,7 +95,7 @@ public class RenderRegionManager {
             return;
         }
 
-        var resources = region.createResources(commandList);
+        var resources = region.createResources(commandList, vertexType);
         var arena = resources.getGeometryArena();
 
         boolean bufferChanged = arena.upload(commandList, uploads.stream()

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderBindingPoints.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderBindingPoints.java
@@ -5,6 +5,7 @@ public class ChunkShaderBindingPoints {
     public static final int ATTRIBUTE_COLOR = 1;
     public static final int ATTRIBUTE_BLOCK_TEXTURE = 2;
     public static final int ATTRIBUTE_LIGHT_TEXTURE = 3;
+    public static final int ATTRIBUTE_NORMAL = 4;
 
     public static final int FRAG_COLOR = 0;
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/shader/ChunkShaderOptions.java
@@ -23,10 +23,7 @@ public record ChunkShaderOptions(ChunkFogMode fog, TerrainRenderPass pass, Chunk
             constants.add("USE_FRAGMENT_DISCARD");
         }
 
-        // Embeddium: indicate whether compact vertex format is disabled to shaders
-        if(this.vertexType != ChunkMeshFormats.VANILLA_LIKE) {
-            constants.add("USE_VERTEX_COMPRESSION");
-        }
+        constants.addAll(this.vertexType.getShaderDefines());
 
         constants.add("VERT_POS_SCALE", String.valueOf(this.vertexType.getPositionScale()));
         constants.add("VERT_POS_OFFSET", String.valueOf(this.vertexType.getPositionOffset()));

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkMeshAttribute.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkMeshAttribute.java
@@ -4,5 +4,6 @@ public enum ChunkMeshAttribute {
     POSITION_MATERIAL_MESH,
     COLOR_SHADE,
     BLOCK_TEXTURE,
-    LIGHT_TEXTURE
+    LIGHT_TEXTURE,
+    NORMAL
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkMeshFormats.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkMeshFormats.java
@@ -1,9 +1,11 @@
 package me.jellysquid.mods.sodium.client.render.chunk.vertex.format;
 
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.impl.CompactChunkVertex;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.impl.VanillaChunkVertex;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.impl.VanillaLikeChunkVertex;
 
 public class ChunkMeshFormats {
     public static final ChunkVertexType COMPACT = new CompactChunkVertex();
     public static final ChunkVertexType VANILLA_LIKE = new VanillaLikeChunkVertex();
+    public static final ChunkVertexType VANILLA = new VanillaChunkVertex();
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkVertexEncoder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkVertexEncoder.java
@@ -13,6 +13,11 @@ public interface ChunkVertexEncoder {
         public float u;
         public float v;
         public int light;
+        /**
+         * The normal that vanilla would output for this quad. Unused by Embeddium's built-in shaders, but might be used
+         * by a core shader.
+         */
+        public int normal;
 
         public static Vertex[] uninitializedQuad() {
             Vertex[] vertices = new Vertex[4];

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkVertexType.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkVertexType.java
@@ -1,6 +1,10 @@
 package me.jellysquid.mods.sodium.client.render.chunk.vertex.format;
 
+import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexAttributeBinding;
 import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexFormat;
+import me.jellysquid.mods.sodium.client.render.chunk.shader.ChunkShaderBindingPoints;
+
+import java.util.List;
 
 public interface ChunkVertexType {
     /**
@@ -21,4 +25,23 @@ public interface ChunkVertexType {
     GlVertexFormat<ChunkMeshAttribute> getVertexFormat();
 
     ChunkVertexEncoder getEncoder();
+
+    default GlVertexAttributeBinding[] getAttributeBindings() {
+        var vertexFormat = getVertexFormat();
+        return new GlVertexAttributeBinding[] {
+                new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_POSITION_ID,
+                        vertexFormat.getAttribute(ChunkMeshAttribute.POSITION_MATERIAL_MESH)),
+                new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_COLOR,
+                        vertexFormat.getAttribute(ChunkMeshAttribute.COLOR_SHADE)),
+                new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_BLOCK_TEXTURE,
+                        vertexFormat.getAttribute(ChunkMeshAttribute.BLOCK_TEXTURE)),
+                new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_LIGHT_TEXTURE,
+                        vertexFormat.getAttribute(ChunkMeshAttribute.LIGHT_TEXTURE))
+        };
+    }
+
+    // TODO post-BC: make this have no default impl
+    default List<String> getShaderDefines() {
+        return List.of("USE_VERTEX_COMPRESSION");
+    }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaChunkVertex.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaChunkVertex.java
@@ -1,7 +1,9 @@
 package me.jellysquid.mods.sodium.client.render.chunk.vertex.format.impl;
 
+import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexAttributeBinding;
 import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexAttributeFormat;
 import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexFormat;
+import me.jellysquid.mods.sodium.client.render.chunk.shader.ChunkShaderBindingPoints;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshAttribute;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEncoder;
@@ -24,7 +26,7 @@ public class VanillaChunkVertex implements ChunkVertexType {
             .addElement(ChunkMeshAttribute.COLOR_SHADE, 12, GlVertexAttributeFormat.UNSIGNED_BYTE, 4, true, false)
             .addElement(ChunkMeshAttribute.BLOCK_TEXTURE, 16, GlVertexAttributeFormat.FLOAT, 2, false, false)
             .addElement(ChunkMeshAttribute.LIGHT_TEXTURE, 24, GlVertexAttributeFormat.UNSIGNED_SHORT, 2, false, true)
-            //.addElement(ChunkMeshAttribute.NORMAL, 28, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
+            .addElement(ChunkMeshAttribute.NORMAL, 28, GlVertexAttributeFormat.SIGNED_BYTE, 3, true, false)
             .build();
 
     @Override
@@ -59,11 +61,26 @@ public class VanillaChunkVertex implements ChunkVertexType {
             MemoryUtil.memPutInt(ptr + 12, ColorABGR.withAlpha(ColorMixer.mulSingle(c, ColorABGR.unpackAlpha(c)), 255));
             MemoryUtil.memPutFloat(ptr + 16, encodeTexture(vertex.u));
             MemoryUtil.memPutFloat(ptr + 20, encodeTexture(vertex.v));
-            // TODO
             MemoryUtil.memPutInt(ptr + 24, vertex.light);
-            MemoryUtil.memPutInt(ptr + 28, 0);
+            MemoryUtil.memPutInt(ptr + 28, vertex.normal);
 
             return ptr + STRIDE;
+        };
+    }
+
+    @Override
+    public GlVertexAttributeBinding[] getAttributeBindings() {
+        return new GlVertexAttributeBinding[] {
+                new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_POSITION_ID,
+                        VERTEX_FORMAT.getAttribute(ChunkMeshAttribute.POSITION_MATERIAL_MESH)),
+                new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_COLOR,
+                        VERTEX_FORMAT.getAttribute(ChunkMeshAttribute.COLOR_SHADE)),
+                new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_BLOCK_TEXTURE,
+                        VERTEX_FORMAT.getAttribute(ChunkMeshAttribute.BLOCK_TEXTURE)),
+                new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_LIGHT_TEXTURE,
+                        VERTEX_FORMAT.getAttribute(ChunkMeshAttribute.LIGHT_TEXTURE)),
+                new GlVertexAttributeBinding(ChunkShaderBindingPoints.ATTRIBUTE_NORMAL,
+                        VERTEX_FORMAT.getAttribute(ChunkMeshAttribute.NORMAL))
         };
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaChunkVertex.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaChunkVertex.java
@@ -7,21 +7,22 @@ import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshAttr
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEncoder;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
 import net.caffeinemc.mods.sodium.api.util.ColorABGR;
-import net.caffeinemc.mods.sodium.api.util.ColorU8;
+import net.caffeinemc.mods.sodium.api.util.ColorMixer;
 import org.lwjgl.system.MemoryUtil;
 
 /**
- * This vertex format is less performant and uses more VRAM than {@link CompactChunkVertex}, but should be completely
- * compatible with mods & resource packs that need high precision for models.
+ * This vertex format uses the same format as {@link com.mojang.blaze3d.vertex.DefaultVertexFormat#BLOCK}. It is not
+ * intended to be used with Embeddium's shaders.
  */
-public class VanillaLikeChunkVertex implements ChunkVertexType {
-    public static final int STRIDE = 28;
+public class VanillaChunkVertex implements ChunkVertexType {
+    public static final int STRIDE = 32;
 
     public static final GlVertexFormat<ChunkMeshAttribute> VERTEX_FORMAT = GlVertexFormat.builder(ChunkMeshAttribute.class, STRIDE)
             .addElement(ChunkMeshAttribute.POSITION_MATERIAL_MESH, 0, GlVertexAttributeFormat.FLOAT, 3, false, false)
             .addElement(ChunkMeshAttribute.COLOR_SHADE, 12, GlVertexAttributeFormat.UNSIGNED_BYTE, 4, true, false)
             .addElement(ChunkMeshAttribute.BLOCK_TEXTURE, 16, GlVertexAttributeFormat.FLOAT, 2, false, false)
-            .addElement(ChunkMeshAttribute.LIGHT_TEXTURE, 24, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
+            .addElement(ChunkMeshAttribute.LIGHT_TEXTURE, 24, GlVertexAttributeFormat.UNSIGNED_SHORT, 2, false, true)
+            //.addElement(ChunkMeshAttribute.NORMAL, 28, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
             .build();
 
     @Override
@@ -50,10 +51,15 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
             MemoryUtil.memPutFloat(ptr + 0, vertex.x);
             MemoryUtil.memPutFloat(ptr + 4, vertex.y);
             MemoryUtil.memPutFloat(ptr + 8, vertex.z);
-            MemoryUtil.memPutInt(ptr + 12, vertex.color);
+
+            // Unpack brightness and apply it to the other three color values to match vanilla format
+            int c = vertex.color;
+            MemoryUtil.memPutInt(ptr + 12, ColorABGR.withAlpha(ColorMixer.mulSingle(c, ColorABGR.unpackAlpha(c)), 255));
             MemoryUtil.memPutFloat(ptr + 16, encodeTexture(vertex.u));
             MemoryUtil.memPutFloat(ptr + 20, encodeTexture(vertex.v));
-            MemoryUtil.memPutInt(ptr + 24, (encodeDrawParameters(material, sectionIndex) << 0) | (encodeLight(vertex.light) << 16));
+            // TODO
+            MemoryUtil.memPutInt(ptr + 24, vertex.light);
+            MemoryUtil.memPutInt(ptr + 28, encodeDrawParameters(material, sectionIndex));
 
             return ptr + STRIDE;
         };
@@ -61,12 +67,6 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
 
     private static int encodeDrawParameters(Material material, int sectionIndex) {
         return (((sectionIndex & 0xFF) << 8) | ((material.bits() & 0xFF) << 0));
-    }
-
-    private static int encodeLight(int light) {
-        int block = light & 0xFF;
-        int sky = (light >> 16) & 0xFF;
-        return ((block << 0) | (sky << 8));
     }
 
     private static float encodeTexture(float value) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaChunkVertex.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaChunkVertex.java
@@ -10,6 +10,8 @@ import net.caffeinemc.mods.sodium.api.util.ColorABGR;
 import net.caffeinemc.mods.sodium.api.util.ColorMixer;
 import org.lwjgl.system.MemoryUtil;
 
+import java.util.List;
+
 /**
  * This vertex format uses the same format as {@link com.mojang.blaze3d.vertex.DefaultVertexFormat#BLOCK}. It is not
  * intended to be used with Embeddium's shaders.
@@ -59,17 +61,18 @@ public class VanillaChunkVertex implements ChunkVertexType {
             MemoryUtil.memPutFloat(ptr + 20, encodeTexture(vertex.v));
             // TODO
             MemoryUtil.memPutInt(ptr + 24, vertex.light);
-            MemoryUtil.memPutInt(ptr + 28, encodeDrawParameters(material, sectionIndex));
+            MemoryUtil.memPutInt(ptr + 28, 0);
 
             return ptr + STRIDE;
         };
     }
 
-    private static int encodeDrawParameters(Material material, int sectionIndex) {
-        return (((sectionIndex & 0xFF) << 8) | ((material.bits() & 0xFF) << 0));
-    }
-
     private static float encodeTexture(float value) {
         return Math.min(0.99999997F, value);
+    }
+
+    @Override
+    public List<String> getShaderDefines() {
+        return List.of();
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaLikeChunkVertex.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaLikeChunkVertex.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.sodium.client.render.chunk.vertex.format.impl;
 
+import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexAttributeBinding;
 import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexAttributeFormat;
 import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexFormat;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
@@ -9,6 +10,8 @@ import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexTy
 import net.caffeinemc.mods.sodium.api.util.ColorABGR;
 import net.caffeinemc.mods.sodium.api.util.ColorU8;
 import org.lwjgl.system.MemoryUtil;
+
+import java.util.List;
 
 /**
  * This vertex format is less performant and uses more VRAM than {@link CompactChunkVertex}, but should be completely
@@ -71,5 +74,10 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
 
     private static float encodeTexture(float value) {
         return Math.min(0.99999997F, value);
+    }
+
+    @Override
+    public List<String> getShaderDefines() {
+        return List.of();
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaLikeChunkVertex.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaLikeChunkVertex.java
@@ -7,6 +7,7 @@ import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshAttr
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEncoder;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
 import net.caffeinemc.mods.sodium.api.util.ColorABGR;
+import net.caffeinemc.mods.sodium.api.util.ColorMixer;
 import net.caffeinemc.mods.sodium.api.util.ColorU8;
 import org.lwjgl.system.MemoryUtil;
 
@@ -21,7 +22,7 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
             .addElement(ChunkMeshAttribute.POSITION_MATERIAL_MESH, 0, GlVertexAttributeFormat.FLOAT, 3, false, false)
             .addElement(ChunkMeshAttribute.COLOR_SHADE, 12, GlVertexAttributeFormat.UNSIGNED_BYTE, 4, true, false)
             .addElement(ChunkMeshAttribute.BLOCK_TEXTURE, 16, GlVertexAttributeFormat.FLOAT, 2, false, false)
-            .addElement(ChunkMeshAttribute.LIGHT_TEXTURE, 24, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
+            .addElement(ChunkMeshAttribute.LIGHT_TEXTURE, 24, GlVertexAttributeFormat.UNSIGNED_SHORT, 2, false, true)
             //.addElement(ChunkMeshAttribute.NORMAL, 28, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
             .build();
 
@@ -51,7 +52,10 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
             MemoryUtil.memPutFloat(ptr + 0, vertex.x);
             MemoryUtil.memPutFloat(ptr + 4, vertex.y);
             MemoryUtil.memPutFloat(ptr + 8, vertex.z);
-            MemoryUtil.memPutInt(ptr + 12, ColorABGR.withAlpha(vertex.color, 255));
+
+            // Unpack brightness and apply it to the other three color values to match vanilla format
+            int c = vertex.color;
+            MemoryUtil.memPutInt(ptr + 12, ColorABGR.withAlpha(ColorMixer.mulSingle(c, ColorABGR.unpackAlpha(c)), 255));
             MemoryUtil.memPutFloat(ptr + 16, encodeTexture(vertex.u));
             MemoryUtil.memPutFloat(ptr + 20, encodeTexture(vertex.v));
             // TODO

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaLikeChunkVertex.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/vertex/format/impl/VanillaLikeChunkVertex.java
@@ -15,13 +15,14 @@ import org.lwjgl.system.MemoryUtil;
  * compatible with mods & resource packs that need high precision for models.
  */
 public class VanillaLikeChunkVertex implements ChunkVertexType {
-    public static final int STRIDE = 28;
+    public static final int STRIDE = 32;
 
     public static final GlVertexFormat<ChunkMeshAttribute> VERTEX_FORMAT = GlVertexFormat.builder(ChunkMeshAttribute.class, STRIDE)
             .addElement(ChunkMeshAttribute.POSITION_MATERIAL_MESH, 0, GlVertexAttributeFormat.FLOAT, 3, false, false)
             .addElement(ChunkMeshAttribute.COLOR_SHADE, 12, GlVertexAttributeFormat.UNSIGNED_BYTE, 4, true, false)
             .addElement(ChunkMeshAttribute.BLOCK_TEXTURE, 16, GlVertexAttributeFormat.FLOAT, 2, false, false)
             .addElement(ChunkMeshAttribute.LIGHT_TEXTURE, 24, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
+            //.addElement(ChunkMeshAttribute.NORMAL, 28, GlVertexAttributeFormat.UNSIGNED_INT, 1, false, true)
             .build();
 
     @Override
@@ -50,10 +51,12 @@ public class VanillaLikeChunkVertex implements ChunkVertexType {
             MemoryUtil.memPutFloat(ptr + 0, vertex.x);
             MemoryUtil.memPutFloat(ptr + 4, vertex.y);
             MemoryUtil.memPutFloat(ptr + 8, vertex.z);
-            MemoryUtil.memPutInt(ptr + 12, vertex.color);
+            MemoryUtil.memPutInt(ptr + 12, ColorABGR.withAlpha(vertex.color, 255));
             MemoryUtil.memPutFloat(ptr + 16, encodeTexture(vertex.u));
             MemoryUtil.memPutFloat(ptr + 20, encodeTexture(vertex.v));
-            MemoryUtil.memPutInt(ptr + 24, (encodeDrawParameters(material, sectionIndex) << 0) | (encodeLight(vertex.light) << 16));
+            // TODO
+            MemoryUtil.memPutInt(ptr + 24, vertex.light);
+            MemoryUtil.memPutInt(ptr + 28, encodeDrawParameters(material, sectionIndex));
 
             return ptr + STRIDE;
         };

--- a/src/main/java/org/embeddedt/embeddium/chunk/VanillaShaderChunkRenderer.java
+++ b/src/main/java/org/embeddedt/embeddium/chunk/VanillaShaderChunkRenderer.java
@@ -13,6 +13,7 @@ import me.jellysquid.mods.sodium.client.render.chunk.data.SectionRenderDataUnsaf
 import me.jellysquid.mods.sodium.client.render.chunk.lists.ChunkRenderList;
 import me.jellysquid.mods.sodium.client.render.chunk.lists.ChunkRenderListIterable;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshFormats;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
 import me.jellysquid.mods.sodium.client.render.viewport.CameraTransform;
 import net.minecraft.client.renderer.ShaderInstance;
@@ -24,12 +25,12 @@ import java.util.Objects;
 
 public class VanillaShaderChunkRenderer extends DefaultChunkRenderer {
 
-    public VanillaShaderChunkRenderer(RenderDevice device, ChunkVertexType vertexType) {
-        super(device, vertexType);
+    public VanillaShaderChunkRenderer(RenderDevice device) {
+        super(device, ChunkMeshFormats.VANILLA);
     }
 
     private boolean isVanillaPass(TerrainRenderPass pass) {
-        return SodiumClientMod.canUseVanillaVertices();
+        return true;
     }
 
     @Override

--- a/src/main/java/org/embeddedt/embeddium/chunk/VanillaShaderChunkRenderer.java
+++ b/src/main/java/org/embeddedt/embeddium/chunk/VanillaShaderChunkRenderer.java
@@ -1,0 +1,182 @@
+package org.embeddedt.embeddium.chunk;
+
+import com.mojang.blaze3d.shaders.Uniform;
+import com.mojang.blaze3d.systems.RenderSystem;
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
+import me.jellysquid.mods.sodium.client.gl.device.CommandList;
+import me.jellysquid.mods.sodium.client.gl.device.RenderDevice;
+import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import me.jellysquid.mods.sodium.client.render.chunk.ChunkRenderMatrices;
+import me.jellysquid.mods.sodium.client.render.chunk.DefaultChunkRenderer;
+import me.jellysquid.mods.sodium.client.render.chunk.LocalSectionIndex;
+import me.jellysquid.mods.sodium.client.render.chunk.data.SectionRenderDataUnsafe;
+import me.jellysquid.mods.sodium.client.render.chunk.lists.ChunkRenderList;
+import me.jellysquid.mods.sodium.client.render.chunk.lists.ChunkRenderListIterable;
+import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
+import me.jellysquid.mods.sodium.client.render.viewport.CameraTransform;
+import net.minecraft.client.renderer.ShaderInstance;
+import org.joml.Matrix4f;
+
+import java.util.Iterator;
+import java.util.Objects;
+
+public class VanillaShaderChunkRenderer extends DefaultChunkRenderer {
+
+    public VanillaShaderChunkRenderer(RenderDevice device, ChunkVertexType vertexType) {
+        super(device, vertexType);
+    }
+
+    private boolean isVanillaPass(TerrainRenderPass pass) {
+        return true;
+    }
+
+    @Override
+    protected void begin(TerrainRenderPass pass) {
+        if(isVanillaPass(pass)) {
+            pass.startDrawing();
+        } else {
+            super.begin(pass);
+        }
+    }
+
+    @Override
+    protected void end(TerrainRenderPass pass) {
+        if(isVanillaPass(pass)) {
+
+        } else {
+            super.end(pass);
+        }
+    }
+
+    private void applyShaderState(ShaderInstance shaderinstance, ChunkRenderMatrices matrices) {
+        for(int i = 0; i < 12; ++i) {
+            int j1 = RenderSystem.getShaderTexture(i);
+            shaderinstance.setSampler("Sampler" + i, j1);
+        }
+
+        if (shaderinstance.MODEL_VIEW_MATRIX != null) {
+            shaderinstance.MODEL_VIEW_MATRIX.set((Matrix4f)matrices.modelView());
+        }
+
+        if (shaderinstance.PROJECTION_MATRIX != null) {
+            shaderinstance.PROJECTION_MATRIX.set((Matrix4f)matrices.projection());
+        }
+
+        if (shaderinstance.COLOR_MODULATOR != null) {
+            shaderinstance.COLOR_MODULATOR.set(RenderSystem.getShaderColor());
+        }
+
+        if (shaderinstance.GLINT_ALPHA != null) {
+            shaderinstance.GLINT_ALPHA.set(RenderSystem.getShaderGlintAlpha());
+        }
+
+        if (shaderinstance.FOG_START != null) {
+            shaderinstance.FOG_START.set(RenderSystem.getShaderFogStart());
+        }
+
+        if (shaderinstance.FOG_END != null) {
+            shaderinstance.FOG_END.set(RenderSystem.getShaderFogEnd());
+        }
+
+        if (shaderinstance.FOG_COLOR != null) {
+            shaderinstance.FOG_COLOR.set(RenderSystem.getShaderFogColor());
+        }
+
+        if (shaderinstance.FOG_SHAPE != null) {
+            shaderinstance.FOG_SHAPE.set(RenderSystem.getShaderFogShape().getIndex());
+        }
+
+        if (shaderinstance.TEXTURE_MATRIX != null) {
+            shaderinstance.TEXTURE_MATRIX.set(RenderSystem.getTextureMatrix());
+        }
+
+        if (shaderinstance.GAME_TIME != null) {
+            shaderinstance.GAME_TIME.set(RenderSystem.getShaderGameTime());
+        }
+
+        RenderSystem.setupShaderLights(shaderinstance);
+        shaderinstance.apply();
+    }
+
+    private void renderRegion(TerrainRenderPass renderPass, Uniform chunkOffset, ChunkRenderList renderList, CameraTransform camera, CommandList commandList) {
+        var region = renderList.getRegion();
+        var storage = region.getStorage(renderPass);
+
+        if(storage == null) {
+            return;
+        }
+
+        var sectionIterator = renderList.sectionsWithGeometryIterator(renderPass.isReverseOrder());
+
+        if(sectionIterator == null) {
+            return;
+        }
+
+        boolean useBlockFaceCulling = SodiumClientMod.options().performance.useBlockFaceCulling;
+
+        while(sectionIterator.hasNext()) {
+            int sectionIndex = sectionIterator.nextByteAsInt();
+
+            int originX = region.getChunkX() + LocalSectionIndex.unpackX(sectionIndex);
+            int originY = region.getChunkY() + LocalSectionIndex.unpackY(sectionIndex);
+            int originZ = region.getChunkZ() + LocalSectionIndex.unpackZ(sectionIndex);
+
+            var pMeshData = storage.getDataPointer(sectionIndex);
+
+            if (chunkOffset != null) {
+                chunkOffset.set((float)((double)originX - camera.x), (float)((double)originY - camera.y), (float)((double)originZ - camera.z));
+                chunkOffset.upload();
+            }
+
+            int slices;
+
+            if (useBlockFaceCulling && (!renderPass.isReverseOrder() || !SodiumClientMod.canApplyTranslucencySorting())) {
+                slices = getVisibleFaces(camera.intX, camera.intY, camera.intZ, originX, originY, originZ);
+            } else {
+                slices = ModelQuadFacing.ALL;
+            }
+
+            slices &= SectionRenderDataUnsafe.getSliceMask(pMeshData);
+
+            // Set up the draw commands for this batch
+            if (slices != 0) {
+                addDrawCommands(batch, pMeshData, slices);
+            }
+
+            this.sharedIndexBuffer.ensureCapacity(commandList, this.batch.getIndexBufferSize());
+            var tessellation = this.prepareTessellation(commandList, region);
+            executeDrawBatch(commandList, tessellation, this.batch);
+        }
+    }
+
+    @Override
+    public void render(ChunkRenderMatrices matrices, CommandList commandList, ChunkRenderListIterable renderLists, TerrainRenderPass renderPass, CameraTransform camera) {
+        if(isVanillaPass(renderPass)) {
+            begin(renderPass);
+            ShaderInstance shaderinstance = Objects.requireNonNull(RenderSystem.getShader(), "Shader not bound");
+
+            applyShaderState(shaderinstance, matrices);
+
+            Uniform chunkOffset = shaderinstance.CHUNK_OFFSET;
+
+            Iterator<ChunkRenderList> iterator = renderLists.iterator(renderPass.isReverseOrder());
+
+            while (iterator.hasNext()) {
+                ChunkRenderList renderList = iterator.next();
+
+                renderRegion(renderPass, chunkOffset, renderList, camera, commandList);
+            }
+
+            if(chunkOffset != null) {
+                chunkOffset.set(0f, 0f, 0f);
+            }
+
+            shaderinstance.clear();
+
+            end(renderPass);
+        } else {
+            super.render(matrices, commandList, renderLists, renderPass, camera);
+        }
+    }
+}

--- a/src/main/java/org/embeddedt/embeddium/render/chunk/ChunkVertexTypeManager.java
+++ b/src/main/java/org/embeddedt/embeddium/render/chunk/ChunkVertexTypeManager.java
@@ -1,0 +1,30 @@
+package org.embeddedt.embeddium.render.chunk;
+
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
+import me.jellysquid.mods.sodium.client.render.chunk.RenderSectionManager;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshFormats;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
+
+import java.util.Objects;
+
+public class ChunkVertexTypeManager {
+    private static ChunkVertexType currentType;
+
+    public static void updateType() {
+        ChunkVertexType vertexType;
+
+        if (RenderSectionManager.USE_CORE_SHADERS) {
+            vertexType = ChunkMeshFormats.VANILLA;
+        } else if (SodiumClientMod.canUseVanillaVertices()) {
+            vertexType = ChunkMeshFormats.VANILLA_LIKE;
+        } else {
+            vertexType = ChunkMeshFormats.COMPACT;
+        }
+
+        currentType = vertexType;
+    }
+
+    public static ChunkVertexType getType() {
+        return Objects.requireNonNull(currentType);
+    }
+}


### PR DESCRIPTION
This PR lays some early groundwork for a hybridized renderer that is capable of using vanilla core shaders (if necessary) and more efficient shaders otherwise.

**These changes are not sufficient to use resource packs that modify terrain shaders. If you are a user, do not expect that builds from this PR will function with core shaders.**

The change set is as follows:

* Introduce `VanillaShaderChunkRenderer`, which draws chunks from our vertex buffers using the appropriate vanilla core shader. This renderer is rather inefficient compared to the regular one, as it only issues multidraw calls for one section at a time, rather than one region. This is because the vanilla shader expects the chunk offset uniform to be updated for each section.
* Introduce a third vertex type (used internally) which produces data in the same format as `DefaultVertexFormat.BLOCK`.
* Clean up vertex types so that they are selected in one central location.
* Add a system property for testing `VanillaShaderChunkRenderer` (otherwise, the normal renderer is used).

More work is needed for this to be usable in practice. In particular:

* It needs to be possible to select separate vertex types for each render pass. Otherwise, all chunks must use the vanilla-like vertex type, which is problematic both for performance and for the implementation (as there isn't space for the extra data our shader needs from the vertex).
* Some simple core shaders need to be found to do testing with.
* Currently, the Embeddium renderer only has three render passes (solid/cutout/translucent); data from the other passes is merged. This will likely need to be disabled if resource packs override the tripwire or mipped cutout shaders.
* Sugarcane disappears at a significant enough distance when testing with the vanilla terrain shader. This is likely related to the point above.