### PR TITLE
Apply directional shading based on normal for non-vanilla quads

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/ccl/SinkingVertexBuilder.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/ccl/SinkingVertexBuilder.java
@@ -118,6 +118,11 @@ public final class SinkingVertexBuilder implements VertexConsumer {
         public int getForgeNormal(int idx) {
             return 0;
         }
+
+        @Override
+        public int getComputedFaceNormal() {
+            return 0;
+        }
     };
 
     private static ByteBuffer reallocDirect(ByteBuffer old, int capacity) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -21,6 +21,7 @@ import me.jellysquid.mods.sodium.client.render.chunk.compile.executor.ChunkBuild
 import net.minecraft.client.*;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.common.ForgeConfig;
 import org.embeddedt.embeddium.client.gui.options.StandardOptions;
 import org.embeddedt.embeddium.render.ShaderModBridge;
 import org.lwjgl.opengl.GL;
@@ -284,6 +285,18 @@ public class SodiumGameOptionPages {
                         .setImpact(OptionImpact.VARIES)
                         .setBinding((opts, value) -> opts.performance.useTranslucentFaceSorting = value, opts -> opts.performance.useTranslucentFaceSorting)
                         .setEnabled(!ShaderModBridge.isNvidiumEnabled())
+                        .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
+                        .build())
+                .build());
+
+        groups.add(OptionGroup.createBuilder()
+                .setId(StandardOptions.Group.LIGHTING)
+                .add(OptionImpl.createBuilder(boolean.class, sodiumOpts)
+                        .setId(StandardOptions.Option.USE_QUAD_NORMALS_FOR_LIGHTING)
+                        .setControl(TickBoxControl::new)
+                        .setImpact(OptionImpact.LOW)
+                        .setBinding((opts, value) -> opts.quality.useQuadNormalsForShading = value, opts -> opts.quality.useQuadNormalsForShading)
+                        .setEnabled(!ForgeConfig.CLIENT.experimentalForgeLightPipelineEnabled.get())
                         .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                         .build())
                 .build());

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptions.java
@@ -67,6 +67,8 @@ public class SodiumGameOptions {
         public GraphicsQuality leavesQuality = GraphicsQuality.DEFAULT;
 
         public boolean enableVignette = true;
+
+        public boolean useQuadNormalsForShading = false;
     }
 
     public static class NotificationSettings {

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/light/flat/FlatLightPipeline.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/light/flat/FlatLightPipeline.java
@@ -5,6 +5,7 @@ import me.jellysquid.mods.sodium.client.model.light.data.LightDataAccess;
 import me.jellysquid.mods.sodium.client.model.light.data.QuadLightData;
 import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFlags;
+import net.caffeinemc.mods.sodium.api.util.NormI8;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.core.BlockPos;
@@ -48,7 +49,21 @@ public class FlatLightPipeline implements LightPipeline {
         }
 
         Arrays.fill(out.lm, lightmap);
-        Arrays.fill(out.br, this.lightCache.getWorld().getShade(lightFace, shade));
+        if((quad.getFlags() & ModelQuadFlags.IS_VANILLA_SHADED) != 0) {
+            Arrays.fill(out.br, this.lightCache.getWorld().getShade(lightFace, shade));
+        } else {
+            this.applySidedBrightnessFromNormals(quad, out, shade);
+        }
+    }
+
+    private void applySidedBrightnessFromNormals(ModelQuadView quad, QuadLightData out, boolean shade) {
+        for(int i = 0; i < 4; i++) {
+            int normal = quad.getForgeNormal(i);
+            if (normal == 0) {
+                normal = quad.getComputedFaceNormal();
+            }
+            out.br[i] = this.lightCache.getWorld().getShade(NormI8.unpackX(normal), NormI8.unpackY(normal), NormI8.unpackZ(normal), shade);
+        }
     }
 
     /**

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/light/smooth/SmoothLightPipeline.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/light/smooth/SmoothLightPipeline.java
@@ -5,6 +5,7 @@ import me.jellysquid.mods.sodium.client.model.light.data.LightDataAccess;
 import me.jellysquid.mods.sodium.client.model.light.data.QuadLightData;
 import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFlags;
+import net.caffeinemc.mods.sodium.api.util.NormI8;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.Mth;
@@ -87,7 +88,11 @@ public class SmoothLightPipeline implements LightPipeline {
             this.applyNonParallelFace(neighborInfo, quad, pos, lightFace, out);
         }
 
-        this.applySidedBrightness(out, lightFace, shade);
+        if((flags & ModelQuadFlags.IS_VANILLA_SHADED) != 0) {
+            this.applySidedBrightness(out, lightFace, shade);
+        } else {
+            this.applySidedBrightnessFromNormals(out, quad, shade);
+        }
     }
 
     @Override
@@ -225,6 +230,18 @@ public class SmoothLightPipeline implements LightPipeline {
 
         for (int i = 0; i < br.length; i++) {
             br[i] *= brightness;
+        }
+    }
+
+    private void applySidedBrightnessFromNormals(QuadLightData out, ModelQuadView quad, boolean shade) {
+        float[] br = out.br;
+
+        for (int i = 0; i < br.length; i++) {
+            int normal = quad.getForgeNormal(i);
+            if (normal == 0) {
+                normal = quad.getComputedFaceNormal();
+            }
+            br[i] *= this.lightCache.getWorld().getShade(NormI8.unpackX(normal), NormI8.unpackY(normal), NormI8.unpackZ(normal), shade);
         }
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/quad/BakedQuadView.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/quad/BakedQuadView.java
@@ -7,4 +7,6 @@ public interface BakedQuadView extends ModelQuadView {
     ModelQuadFacing getNormalFace();
 
     boolean hasShade();
+
+    void setFlags(int flags);
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/quad/ModelQuad.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/quad/ModelQuad.java
@@ -2,6 +2,7 @@ package me.jellysquid.mods.sodium.client.model.quad;
 
 import static me.jellysquid.mods.sodium.client.util.ModelQuadUtil.*;
 
+import me.jellysquid.mods.sodium.client.util.ModelQuadUtil;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.Direction;
 
@@ -122,6 +123,11 @@ public class ModelQuad implements ModelQuadViewMutable {
     @Override
     public int getForgeNormal(int idx) {
         return this.data[vertexOffset(idx) + NORMAL_INDEX];
+    }
+
+    @Override
+    public int getComputedFaceNormal() {
+        return ModelQuadUtil.calculateNormal(this);
     }
 
     @Override

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/quad/ModelQuadView.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/quad/ModelQuadView.java
@@ -66,6 +66,8 @@ public interface ModelQuadView {
 
     int getForgeNormal(int idx);
 
+    int getComputedFaceNormal();
+
     default boolean hasColor() {
         return this.getColorIndex() != -1;
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/quad/properties/ModelQuadFlags.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/quad/properties/ModelQuadFlags.java
@@ -22,6 +22,12 @@ public class ModelQuadFlags {
     public static final int IS_ALIGNED = 0b100;
 
     /**
+     * Indicates that the quad should be shaded using vanilla's getShade logic and the light face, rather than
+     * the normals of each vertex.
+     */
+    public static final int IS_VANILLA_SHADED = 0b1000;
+
+    /**
      * @return True if the bit-flag of {@link ModelQuadFlags} contains the given flag
      */
     public static boolean contains(int flags, int mask) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/FluidRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/pipeline/FluidRenderer.java
@@ -220,7 +220,7 @@ public class FluidRenderer {
         LightMode lightMode = isWater && Minecraft.useAmbientOcclusion() ? LightMode.SMOOTH : LightMode.FLAT;
         LightPipeline lighter = this.lighters.getLighter(lightMode);
 
-        quad.setFlags(0);
+        quad.setFlags(ModelQuadFlags.IS_VANILLA_SHADED);
 
         if (!sfUp && this.isSideExposed(world, posX, posY, posZ, Direction.UP, Math.min(Math.min(northWestHeight, southWestHeight), Math.min(southEastHeight, northEastHeight)))) {
             northWestHeight -= EPSILON;
@@ -333,7 +333,7 @@ public class FluidRenderer {
 
         }
 
-        quad.setFlags(ModelQuadFlags.IS_PARALLEL | ModelQuadFlags.IS_ALIGNED);
+        quad.setFlags(ModelQuadFlags.IS_VANILLA_SHADED | ModelQuadFlags.IS_PARALLEL | ModelQuadFlags.IS_ALIGNED);
 
         for (Direction dir : DirectionUtil.HORIZONTAL_DIRECTIONS) {
             float c1;

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/SimpleBakedModelBuilderMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/SimpleBakedModelBuilderMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(SimpleBakedModel.Builder.class)
 public class SimpleBakedModelBuilderMixin {
-    @ModifyArg(method = { "addCulledFace", "addUnculledFace" }, at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", remap = false))
+    @ModifyArg(method = { "addCulledFace", "addUnculledFace" }, at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", remap = false), require = 0)
     private Object setVanillaShadingFlag(Object quad) {
         BakedQuadView view = (BakedQuadView)quad;
         view.setFlags(view.getFlags() | ModelQuadFlags.IS_VANILLA_SHADED);

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/SimpleBakedModelBuilderMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/SimpleBakedModelBuilderMixin.java
@@ -1,0 +1,18 @@
+package me.jellysquid.mods.sodium.mixin.core.model;
+
+import me.jellysquid.mods.sodium.client.model.quad.BakedQuadView;
+import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFlags;
+import net.minecraft.client.resources.model.SimpleBakedModel;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(SimpleBakedModel.Builder.class)
+public class SimpleBakedModelBuilderMixin {
+    @ModifyArg(method = { "addCulledFace", "addUnculledFace" }, at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", remap = false))
+    private Object setVanillaShadingFlag(Object quad) {
+        BakedQuadView view = (BakedQuadView)quad;
+        view.setFlags(view.getFlags() | ModelQuadFlags.IS_VANILLA_SHADED);
+        return quad;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/quad/BakedQuadMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/quad/BakedQuadMixin.java
@@ -126,6 +126,11 @@ public abstract class BakedQuadMixin implements BakedQuadView {
     }
 
     @Override
+    public int getComputedFaceNormal() {
+        return this.normal;
+    }
+
+    @Override
     public Direction getLightFace() {
         return this.direction;
     }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/quad/BakedQuadMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/core/model/quad/BakedQuadMixin.java
@@ -111,6 +111,11 @@ public abstract class BakedQuadMixin implements BakedQuadView {
     }
 
     @Override
+    public void setFlags(int flags) {
+        this.flags = flags;
+    }
+
+    @Override
     public int getColorIndex() {
         return this.tintIndex;
     }

--- a/src/main/java/org/embeddedt/embeddium/client/gui/options/StandardOptions.java
+++ b/src/main/java/org/embeddedt/embeddium/client/gui/options/StandardOptions.java
@@ -15,6 +15,7 @@ public final class StandardOptions {
         public static final ResourceLocation RENDERING_CULLING = new ResourceLocation(SodiumClientMod.MODID, "rendering_culling");
         public static final ResourceLocation CPU_SAVING = new ResourceLocation(SodiumClientMod.MODID, "cpu_saving");
         public static final ResourceLocation SORTING = new ResourceLocation(SodiumClientMod.MODID, "sorting");
+        public static final ResourceLocation LIGHTING = new ResourceLocation(SodiumClientMod.MODID, "lighting");
     }
 
     public static class Pages {
@@ -57,5 +58,6 @@ public final class StandardOptions {
         public static final ResourceLocation PERSISTENT_MAPPING = new ResourceLocation(SodiumClientMod.MODID, "persistent_mapping");
         public static final ResourceLocation CPU_FRAMES_AHEAD = new ResourceLocation(SodiumClientMod.MODID, "cpu_render_ahead_limit");
         public static final ResourceLocation TRANSLUCENT_FACE_SORTING = new ResourceLocation(SodiumClientMod.MODID, "translucent_face_sorting");
+        public static final ResourceLocation USE_QUAD_NORMALS_FOR_LIGHTING = new ResourceLocation(SodiumClientMod.MODID, "use_quad_normals_for_lighting");
     }
 }

--- a/src/main/resources/assets/embeddium/lang/en_us.json
+++ b/src/main/resources/assets/embeddium/lang/en_us.json
@@ -2,5 +2,7 @@
   "embeddium.conflicting_mod": "Embeddium detected the presence of mods that are known to cause rendering issues/crashes. It is recommended to uninstall them. See the list below.",
   "embeddium.conflicting_mod_list": "[{2}]",
   "embeddium.search_bar_empty": "Search options...",
-  "embeddium.options.added_by_mod_string": "Added by mod: %s"
+  "embeddium.options.added_by_mod_string": "Added by mod: %s",
+  "embeddium.options.use_quad_normals_for_lighting.name": "Use Accurate Quad Shading",
+  "embeddium.options.use_quad_normals_for_lighting.tooltip": "When enabled, Embeddium will apply shading to non-vanilla block faces based on the true direction they are facing, not their axis-aligned direction. This can improve lighting quality when the Forge experimental light pipeline is disabled (which is recommended for best performance).\n\nIt has no effect if the experimental light pipeline is enabled."
 }


### PR DESCRIPTION
The aim of this PR is to improve the out-of-box experience when using Embeddium on (Neo)Forge with modded blocks that render non-axis-aligned geometry, and without enabling the experimental Forge lighting pipeline.

Currently, Embeddium's light pipeline follows vanilla behavior of shading such quads based on their light face. This is correct for AA geometry, but produces weird results for non-AA geometry because the shading is "snapped" to another direction.

![2024-07-14_17 19 17](https://github.com/user-attachments/assets/a2d8f8f3-aac6-4ca5-9c1e-17e7623b9818)

After this PR, the shading is applied using the Forge `getShade` extension that works on arbritrary normal vectors, rather than directions, which fixes the issue.

![2024-07-14_17 16 16](https://github.com/user-attachments/assets/b445157a-9034-4f1e-a3f4-c5bc8263709e)

There remains a parity concern: some vanilla models' appearance changes if normal-based shading is applied to them. This is solved by introducing a new flag that preserves use of the old logic for any quads used in `SimpleBakedModel`s. In general, though, the change is rather insignificant, and so there should not be any negative impact on gameplay if it gets applied to vanilla quads for whatever reason.
