### PR TITLE
Fixed Injection Point in embeddium$renderTextFast for Better Mod Compatibility

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/gui/debug/ForgeGuiMixin.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/render/gui/debug/ForgeGuiMixin.java
@@ -40,7 +40,7 @@ public abstract class ForgeGuiMixin extends Gui {
      * @author embeddedt
      * @reason take over rendering of the actual list contents
      */
-    @Inject(method = "renderHUDText", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/eventbus/api/IEventBus;post(Lnet/minecraftforge/eventbus/api/Event;)Z"), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true, remap = false)
+    @Inject(method = "renderHUDText", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraftforge/eventbus/api/IEventBus;post(Lnet/minecraftforge/eventbus/api/Event;)Z"), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true, remap = false)
     private void embeddium$renderTextFast(int width, int height, PoseStack poseStack, CallbackInfo ci, ArrayList<String> listL, ArrayList<String> listR, CustomizeGuiOverlayEvent.DebugText event) {
         ci.cancel();
 


### PR DESCRIPTION
## Problem
The current implementation of `embeddium$renderTextFast` in `ForgeGuiMixin` poses compatibility issues with mods that utilize `CustomizeGuiOverlayEvent.DebugText.getLeft().add()` (or the `getRight()` equivalent) to add text overlays. This method, with its original `INVOKE` injection point, prematurely cancels the event before other mods have the opportunity to add their text to the screen.

## Impact
This issue affects mods such as AdminShop Overhauled and Project Expansion, which rely on adding text overlays. The result is that when Embeddium is installed alongside these mods, the additional text they attempt to render does not appear, impacting functionality and user experience.

![image](https://github.com/user-attachments/assets/df908a2b-05fd-4bf3-9e46-2ba8b3815c80)

## Solution
Changing the injection point from `INVOKE` to `INVOKE_ASSIGN` resolves this problem by ensuring that `embeddium$renderTextFast` captures the state of the left and right text lists after all modifications by other mods are applied. This adjustment allows the method to properly render all text elements on-screen.

## Conclusion
This pull request improves Embeddium's compatibility with mods using CustomizeGuiOverlayEvent.DebugText to print information to the screen, ensuring that it does not break said mods' functionality.

As the developer for AdminShop, I would really appreciate it if this PR got merged so that I can include Embeddium in my upcoming modpack.